### PR TITLE
Disable text selection

### DIFF
--- a/examples/demo_adwaita.rs
+++ b/examples/demo_adwaita.rs
@@ -100,13 +100,22 @@ fn main() {
     let mut label2 = Label::new("label2");
     label2.set_text("This is Tab 2.");
 
+    let mut label3 = Label::new("label3");
+    label3.unset_selectable();
+    label3.set_text("This label text is unselectable");
+
+    let mut container7 = Container::new("contanier7");
+    container7.set_direction(Direction::Vertical);
+    container7.add(Box::new(label2));
+    container7.add(Box::new(label3));
+
     let tabs_listener = MyTabsListener::new(Rc::clone(&rpanes));
 
     let mut tabs1 = Tabs::new("tabs1");
     tabs1.set_selected(0);
     tabs1.set_listener(Box::new(tabs_listener));
     tabs1.add("Tab 1", Box::new(container6));
-    tabs1.add("Tab 2", Box::new(label2));
+    tabs1.add("Tab 2", Box::new(container7));
 
     let mut quitter = MenuFunction::new("Exit");
     quitter.set_shortcut("Ctrl-Q");

--- a/examples/demo_breeze.rs
+++ b/examples/demo_breeze.rs
@@ -100,13 +100,22 @@ fn main() {
     let mut label2 = Label::new("label2");
     label2.set_text("This is Tab 2.");
 
+    let mut label3 = Label::new("label3");
+    label3.unset_selectable();
+    label3.set_text("This label text is unselectable");
+
+    let mut container7 = Container::new("contanier7");
+    container7.set_direction(Direction::Vertical);
+    container7.add(Box::new(label2));
+    container7.add(Box::new(label3));
+
     let tabs_listener = MyTabsListener::new(Rc::clone(&rpanes));
 
     let mut tabs1 = Tabs::new("tabs1");
     tabs1.set_selected(0);
     tabs1.set_listener(Box::new(tabs_listener));
     tabs1.add("Tab 1", Box::new(container6));
-    tabs1.add("Tab 2", Box::new(label2));
+    tabs1.add("Tab 2", Box::new(container7));
 
     let mut quitter = MenuFunction::new("Exit");
     quitter.set_shortcut("Ctrl-Q");

--- a/examples/demo_default.rs
+++ b/examples/demo_default.rs
@@ -100,13 +100,22 @@ fn main() {
     let mut label2 = Label::new("label2");
     label2.set_text("This is Tab 2.");
 
+    let mut label3 = Label::new("label3");
+    label3.unset_selectable();
+    label3.set_text("This label text is unselectable");
+
+    let mut container7 = Container::new("contanier7");
+    container7.set_direction(Direction::Vertical);
+    container7.add(Box::new(label2));
+    container7.add(Box::new(label3));
+
     let tabs_listener = MyTabsListener::new(Rc::clone(&rpanes));
 
     let mut tabs1 = Tabs::new("tabs1");
     tabs1.set_selected(0);
     tabs1.set_listener(Box::new(tabs_listener));
     tabs1.add("Tab 1", Box::new(container6));
-    tabs1.add("Tab 2", Box::new(label2));
+    tabs1.add("Tab 2", Box::new(container7));
 
     let mut quitter = MenuFunction::new("Exit");
     quitter.set_shortcut("Ctrl-Q");

--- a/examples/demo_osx.rs
+++ b/examples/demo_osx.rs
@@ -100,6 +100,15 @@ fn main() {
     let mut label2 = Label::new("label2");
     label2.set_text("This is Tab 2.");
 
+    let mut label4 = Label::new("label4");
+    label4.unset_selectable();
+    label4.set_text("This label text is unselectable");
+
+    let mut container7 = Container::new("contanier7");
+    container7.set_direction(Direction::Vertical);
+    container7.add(Box::new(label2));
+    container7.add(Box::new(label4));
+
     let mut label3 = Label::new("label3");
     label3.set_text("This is Tab 3.");
 
@@ -109,7 +118,7 @@ fn main() {
     tabs1.set_selected(0);
     tabs1.set_listener(Box::new(tabs_listener));
     tabs1.add("Tab 1", Box::new(container6));
-    tabs1.add("Tab 2", Box::new(label2));
+    tabs1.add("Tab 2", Box::new(container7));
     tabs1.add("Tab 3", Box::new(label3));
 
     let mut quitter = MenuFunction::new("Exit");

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -8,10 +8,12 @@ use crate::widgets::widget::Widget;
 /// ```text
 /// text: String
 /// stretched: bool
+/// selectable: bool
 /// ```
 pub struct LabelState {
     text: String,
     stretched: bool,
+    selectable: bool
 }
 
 impl LabelState {
@@ -25,6 +27,11 @@ impl LabelState {
         self.stretched
     }
 
+    /// Get the selectable flag
+    pub fn selectable(&self) -> bool {
+        self.selectable
+    }
+
     /// Set the text
     pub fn set_text(&mut self, text: &str) {
         self.text = text.to_string();
@@ -33,6 +40,11 @@ impl LabelState {
     /// Set the stretched flag
     pub fn set_stretched(&mut self, stretched: bool) {
         self.stretched = stretched;
+    }
+
+    /// Set the selectable flag
+    pub fn set_selectable(&mut self, selectable: bool) {
+        self.selectable = selectable;
     }
 }
 
@@ -129,6 +141,7 @@ impl Label {
             state: LabelState {
                 text: "Label".to_string(),
                 stretched: false,
+                selectable: true,
             },
             listener: None,
         }
@@ -144,6 +157,11 @@ impl Label {
         self.state.set_stretched(true);
     }
 
+    /// Set the selectable flag to false
+    pub fn unset_selectable(&mut self) {
+        self.state.set_selectable(false);
+    }
+
     /// Set the listener
     pub fn set_listener(&mut self, listener: Box<dyn LabelListener>) {
         self.listener = Some(listener);
@@ -157,10 +175,16 @@ impl Widget for Label {
         } else {
             ""
         };
+        let selectable = if self.state.selectable() {
+            "selectable"
+        } else {
+            ""
+        };
         format!(
-            r#"<div id="{}" class="label {}">{}</div>"#,
+            r#"<div id="{}" class="label {} {}">{}</div>"#,
             self.name,
             stretched,
+            selectable,
             self.state.text()
         )
     }

--- a/src/www/app/app.scss
+++ b/src/www/app/app.scss
@@ -1,3 +1,13 @@
+:not(input, textarea) {
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome and Opera */
+}
+
 body {
     margin: 0;
 }

--- a/src/www/app/app.scss
+++ b/src/www/app/app.scss
@@ -273,3 +273,14 @@ body {
         }
     }
 }
+
+
+.selectable {
+    -webkit-touch-callout: text; /* iOS Safari */
+    -webkit-user-select: text; /* Safari */
+    -khtml-user-select: text; /* Konqueror HTML */
+    -moz-user-select: text; /* Firefox */
+    -ms-user-select: text; /* Internet Explorer/Edge */
+    user-select: text; /* Non-prefixed version, currently
+                                  supported by Chrome and Opera */
+}

--- a/src/www/app/app.scss
+++ b/src/www/app/app.scss
@@ -1,4 +1,4 @@
-:not(input, textarea) {
+:not(input, textarea, .selectable) {
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
     -khtml-user-select: none; /* Konqueror HTML */


### PR DESCRIPTION
Disable text selection on any elements except inputs and textareas.
Add optional selectable state to Label widget