### PR TITLE
Show README.md on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 build = "build.rs"
 description = "A GUI frontend in Rust based on web-view"
 repository = "https://github.com/alexislozano/neutrino/"
+readme = "README.md"
 license = "MIT"
 categories = ["gui"]
 keywords = ["gui", "desktop", "web", "mvc"]


### PR DESCRIPTION
Currently, this crate's page on crates.io only shows the crates description. This PR should make it so that README.md is rendered on the crates.io page.