### PR TITLE
Silence Clippy by implementing `Default::default`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,8 @@ pub struct Window {
     timer: Option<u32>,
 }
 
-impl Window {
-    /// Create a Window
-    pub fn new() -> Self {
+impl Default for Window {
+    fn default() -> Self {
         Self {
             title: "Untitled".to_string(),
             width: 640,
@@ -245,6 +244,13 @@ impl Window {
             listener: None,
             timer: None,
         }
+    }
+}
+
+impl Window {
+    /// Create a Window
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Set the child

--- a/src/widgets/menubar.rs
+++ b/src/widgets/menubar.rs
@@ -135,9 +135,8 @@ pub struct MenuBar {
     listener: Option<Box<dyn MenuBarListener>>,
 }
 
-impl MenuBar {
-    /// Create a MenuBar
-    pub fn new() -> Self {
+impl Default for MenuBar {
+    fn default() -> Self {
         Self {
             items: vec![],
             state: MenuBarState {
@@ -146,6 +145,13 @@ impl MenuBar {
             },
             listener: None,
         }
+    }
+}
+
+impl MenuBar {
+    /// Create a MenuBar
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Set the listener


### PR DESCRIPTION
```
lib.rs:234
you should consider adding a `Default` implementation for `Window`

help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_defaultclippy(clippy::new_without_default)
----
menubar.rs:140
you should consider adding a `Default` implementation for `widgets::menubar::MenuBar`

note: `#[warn(clippy::new_without_default)]` on by default
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_defaultclippy(clippy::new_without_default)
```

Ths PR silences these by implementing `Default` for those two. No breakage expected.