### PR TITLE
Fixed a typo and change the trait implementation order

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -142,7 +142,7 @@ fn main() {
     label3.set_unselectable();
     label3.set_text("This label text is unselectable");
 
-    let mut container7 = Container::new("contanier7");
+    let mut container7 = Container::new("container7");
     container7.set_direction(Direction::Vertical);
     container7.add(Box::new(label2));
     container7.add(Box::new(label3));

--- a/examples/demo_mod/listeners.rs
+++ b/examples/demo_mod/listeners.rs
@@ -199,11 +199,11 @@ impl MyButtonListener {
 }
 
 impl ButtonListener for MyButtonListener {
+    fn on_change(&self, _state: &ButtonState) {}
+
     fn on_update(&self, state: &mut ButtonState) {
         state.set_disabled(self.state.borrow().disabled());
     }
-
-    fn on_change(&self, _state: &ButtonState) {}
 }
 
 pub struct MyComboListener {
@@ -217,11 +217,11 @@ impl MyComboListener {
 }
 
 impl ComboListener for MyComboListener {
+    fn on_change(&self, _state: &ComboState) {}
+
     fn on_update(&self, state: &mut ComboState) {
         state.set_disabled(self.state.borrow().disabled());
     }
-
-    fn on_change(&self, _state: &ComboState) {}
 }
 
 pub struct MyRadioListener {
@@ -235,11 +235,11 @@ impl MyRadioListener {
 }
 
 impl RadioListener for MyRadioListener {
+    fn on_change(&self, _state: &RadioState) {}
+
     fn on_update(&self, state: &mut RadioState) {
         state.set_disabled(self.state.borrow().disabled());
     }
-
-    fn on_change(&self, _state: &RadioState) {}
 }
 
 pub struct MyCheckBoxListener {
@@ -253,11 +253,11 @@ impl MyCheckBoxListener {
 }
 
 impl CheckBoxListener for MyCheckBoxListener {
+    fn on_change(&self, _state: &CheckBoxState) {}
+
     fn on_update(&self, state: &mut CheckBoxState) {
         state.set_disabled(self.state.borrow().disabled());
     }
-
-    fn on_change(&self, _state: &CheckBoxState) {}
 }
 
 pub struct MyCheckBoxDisabledListener {
@@ -271,11 +271,11 @@ impl MyCheckBoxDisabledListener {
 }
 
 impl CheckBoxListener for MyCheckBoxDisabledListener {
-    fn on_update(&self, state: &mut CheckBoxState) {
-        state.set_checked(self.state.borrow().disabled());
-    }
-
     fn on_change(&self, state: &CheckBoxState) {
         self.state.borrow_mut().set_disabled(state.checked());
+    }
+
+    fn on_update(&self, state: &mut CheckBoxState) {
+        state.set_checked(self.state.borrow().disabled());
     }
 }

--- a/examples/image_viewer_mod/listeners.rs
+++ b/examples/image_viewer_mod/listeners.rs
@@ -40,11 +40,11 @@ impl MyPrevButtonListener {
 }
 
 impl ButtonListener for MyPrevButtonListener {
-    fn on_update(&self, _state: &mut ButtonState) {}
-
     fn on_change(&self, _state: &ButtonState) {
         self.images.borrow_mut().previous();
     }
+
+    fn on_update(&self, _state: &mut ButtonState) {}
 }
 
 pub struct MyNextButtonListener {
@@ -58,11 +58,11 @@ impl MyNextButtonListener {
 }
 
 impl ButtonListener for MyNextButtonListener {
-    fn on_update(&self, _state: &mut ButtonState) {}
-
     fn on_change(&self, _state: &ButtonState) {
         self.images.borrow_mut().next();
     }
+
+    fn on_update(&self, _state: &mut ButtonState) {}
 }
 
 pub struct MyMenuBarListener {

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -91,11 +91,11 @@ impl MyUsernameListener {
 }
 
 impl TextInputListener for MyUsernameListener {
+    fn on_update(&self, _state: &mut TextInputState) {}
+
     fn on_change(&self, state: &TextInputState) {
         self.login.borrow_mut().set_username(state.value());
     }
-
-    fn on_update(&self, _state: &mut TextInputState) {}
 }
 
 struct MyPasswordListener {
@@ -109,11 +109,11 @@ impl MyPasswordListener {
 }
 
 impl TextInputListener for MyPasswordListener {
+    fn on_update(&self, _state: &mut TextInputState) {}
+
     fn on_change(&self, state: &TextInputState) {
         self.login.borrow_mut().set_password(state.value());
     }
-
-    fn on_update(&self, _state: &mut TextInputState) {}
 }
 
 fn main() {


### PR DESCRIPTION
The typo was `contanier7` instead of `container7` in `examples/demo.rs` and CLion shows the error "Different impl member order from the trait", if you implement them in a different order. 