### PR TITLE
Add travis CI and code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ addons:
   apt:
     packages:
       - libwebkit2gtk-4.0-dev
+      - cmake
+      - gcc
       - libdw-dev # Required by kcov for code coverage
       - libbfd-dev # Required by kcov for code coverage
       - libelf-dev # Required by kcov for code coverage
@@ -49,7 +51,7 @@ after_success: |
     sudo make install &&
     cd ../.. &&
     rm -rf kcov-master &&
-    for file in target/debug/*.d; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    for file in target/debug/neutrino-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
     bash <(curl -s https://codecov.io/bash) &&
     echo "Uploaded code coverage"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ after_success: |
     sudo make install &&
     cd ../.. &&
     rm -rf kcov-master &&
-    for file in target/debug/neutrino-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    for file in target/debug/neutrino-*.d; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
     bash <(curl -s https://codecov.io/bash) &&
     echo "Uploaded code coverage"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libwebkit2gtk-4.0-dev
       - libdw-dev # Required by kcov for code coverage
       - libbfd-dev # Required by kcov for code coverage
+      - libelf-dev # Required by kcov for code coverage
       - binutils-dev # Required by kcov for code coverage
 
 # This saves doing CI builds twice on each PR (travis does a pre-merge with 'master' and tests that.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,12 @@ matrix:
     - os: osx
       rust: nightly
 
-# This saves doing CI builds and tests double on PRs - uncomment when in neutrino repo
+addons:
+  apt:
+    packages:
+      - libwebkit2gtk-4.0-dev
+
+# This saves doing CI builds twice on each PRs - uncomment this when merged into neutrino upstream repo
 #branches:
 #  only:
 #    - "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,28 @@ addons:
     packages:
       - libwebkit2gtk-4.0-dev
 
-# This saves doing CI builds twice on each PRs - uncomment this when merged into neutrino upstream repo
+# This saves doing CI builds twice on each PR (travis does a pre-merge with 'master' and tests that.
+# But it disables builds on "feature-branches" in forks of the repo, so not so good for contributors.
 #branches:
 #  only:
 #    - "master"
 
 script:
   - cargo test
+
+after_success: |
+  if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+    wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+    tar xzf master.tar.gz &&
+    cd kcov-master &&
+    mkdir build &&
+    cd build &&
+    cmake .. &&
+    make &&
+    sudo make install &&
+    cd ../.. &&
+    rm -rf kcov-master &&
+    for file in target/debug/*.d; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    bash <(curl -s https://codecov.io/bash) &&
+    echo "Uploaded code coverage"
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ after_success: |
     sudo make install &&
     cd ../.. &&
     rm -rf kcov-master &&
-    for file in target/debug/neutrino-*.d; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    for file in target/debug/neutrino-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
     bash <(curl -s https://codecov.io/bash) &&
     echo "Uploaded code coverage"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     packages:
       - libwebkit2gtk-4.0-dev
       - libdw-dev # Required by kcov for code coverage
+      - binutils-dev # Required by kcov for code coverage
 
 # This saves doing CI builds twice on each PR (travis does a pre-merge with 'master' and tests that.
 # But it disables builds on "feature-branches" in forks of the repo, so not so good for contributors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
     - os: osx
       rust: nightly
 
-# This saves doing CI builds and tests double on PRs
-branches:
-  only:
-    - "master"
+# This saves doing CI builds and tests double on PRs - uncomment when in neutrino repo
+#branches:
+#  only:
+#    - "master"
 
 script:
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     packages:
       - libwebkit2gtk-4.0-dev
       - libdw-dev # Required by kcov for code coverage
+      - libbfd-dev # Required by kcov for code coverage
       - binutils-dev # Required by kcov for code coverage
 
 # This saves doing CI builds twice on each PR (travis does a pre-merge with 'master' and tests that.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ matrix:
   include:
     - os: linux
       rust: stable
+    - os: osx
+      rust: stable
+  allow_failures:
     - os: linux
       rust: beta
     - os: linux
       rust: nightly
-    - os: osx
-      rust: stable
     - os: osx
       rust: beta
     - os: osx
@@ -22,6 +23,7 @@ addons:
   apt:
     packages:
       - libwebkit2gtk-4.0-dev
+      - libdw-dev # Required by kcov for code coverage
 
 # This saves doing CI builds twice on each PR (travis does a pre-merge with 'master' and tests that.
 # But it disables builds on "feature-branches" in forks of the repo, so not so good for contributors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: rust
+
+cache:
+  - cargo
+
+matrix:
+  include:
+    - os: linux
+      rust: stable
+    - os: linux
+      rust: beta
+    - os: linux
+      rust: nightly
+    - os: osx
+      rust: stable
+    - os: osx
+      rust: beta
+    - os: osx
+      rust: nightly
+
+# This saves doing CI builds and tests double on PRs
+branches:
+  only:
+    - "master"
+
+script:
+  - cargo test


### PR DESCRIPTION
This PR adds a .travis.yml file to the repo. If the repo is added to your travis-ci.org account then you will have CI integrated into the project. 

I have added code coverage reporting to codecov.io, but in my first test I couldn't get the reports to show - so that's a WIP. If you wanted, we could remove that and try separately.